### PR TITLE
Configure GitHub Actions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,29 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 5
+  },
+  "extends": "eslint:recommended",
+  "env": {
+    "commonjs": true,
+    "browser": true
+  },
+  "rules": {
+    "strict": [2, "global"],
+    "block-scoped-var": 2,
+    "consistent-return": 2,
+    "eqeqeq": [2, "smart"],
+    "guard-for-in": 2,
+    "no-caller": 2,
+    "no-extend-native": 2,
+    "no-loop-func": 2,
+    "no-new": 2,
+    "no-param-reassign": 2,
+    "no-return-assign": 2,
+    "no-unused-expressions": 2,
+    "no-use-before-define": 2,
+    "radix": [2, "always"],
+    "indent": [2, 2],
+    "quotes": [2, "double"],
+    "semi": [2, "always"]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,9 @@
     "commonjs": true,
     "browser": true
   },
+  "globals": {
+     "QueuingStrategy": "readonly"
+  },
   "rules": {
     "strict": [2, "global"],
     "block-scoped-var": 2,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           npm install -g bower
           npm install
           bower install --production
+
       - name: Build source
         run: npm run-script build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: purescript-contrib/setup-purescript@main
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "10"
+
+      - name: Install dependencies
+        run: |
+          npm install -g bower
+          npm install
+          bower install --production
+      - name: Build source
+        run: npm run-script build
+
+      - name: Run tests
+        run: |
+          bower install
+          npm run-script test --if-present

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.*
 !/.gitignore
+!/.eslintrc.json
 !/.github/
 package-lock.json
 /bower_components/

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
+/.*
+!/.gitignore
+!/.github/
+package-lock.json
 /bower_components/
 /node_modules/
-/.pulp-cache/
 /output/
 /generated-docs/
-/.psc-package/
-/.psc*
-/.purs*
-/.psa*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # purescript-web-streams
+
+[![Latest release](http://img.shields.io/github/release/purescript-web/purescript-web-streams.svg)](https://github.com/purescript-web/purescript-web-streams/releases)
+[![Build status](https://github.com/purescript/purescript-web-streams/workflows/CI/badge.svg?branch=master)](https://github.com/purescript/purescript-web-streams/actions?query=workflow%3ACI+branch%3Amaster)
+[![Pursuit](https://pursuit.purescript.org/packages/purescript-web-streams/badge)](https://pursuit.purescript.org/packages/purescript-web-streams)
+
+Type definitions and low level interface implementations for ReadableStream and related types from the [WHATWG Streams Living Standard](https://streams.spec.whatwg.org/).
+
+## Installation
+
+```
+spago install web-streams
+```
+
+## Documentation
+
+Module documentation is [published on Pursuit](http://pursuit.purescript.org/packages/purescript-web-streams).

--- a/package.json
+++ b/package.json
@@ -9,8 +9,5 @@
     "pulp": "^15.0.0",
     "purescript-psa": "^0.8.0",
     "rimraf": "^3.0.2"
-  },
-  "dependencies": {
-    "bower": "^1.8.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "scripts": {
+    "clean": "rimraf output && rimraf .pulp-cache",
+    "build": "eslint src && pulp build -- --censor-lib --strict"
+  },
+  "devDependencies": {
+    "eslint": "^7.15.0",
+    "pulp": "^15.0.0",
+    "purescript-psa": "^0.8.0",
+    "rimraf": "^3.0.2"
+  },
+  "dependencies": {
+    "bower": "^1.8.8"
+  }
+}

--- a/src/Web/Streams/QueuingStrategy.js
+++ b/src/Web/Streams/QueuingStrategy.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.new = function(options) {
   return function() {
     return new QueuingStrategy(options);

--- a/src/Web/Streams/ReadableStream.js
+++ b/src/Web/Streams/ReadableStream.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports._new = function(source, strategy) {
   return new ReadableStream(source, strategy);
 };

--- a/src/Web/Streams/ReadableStreamController.js
+++ b/src/Web/Streams/ReadableStreamController.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.enqueue = function(chunk) {
   return function(controller) {
     return function() {

--- a/src/Web/Streams/Reader.js
+++ b/src/Web/Streams/Reader.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports._read = function(nothing, just, reader) {
   return reader.read().then(function(res) {
     if (res.done) {

--- a/src/Web/Streams/Source.js
+++ b/src/Web/Streams/Source.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports._make = function(options) {
   var newOptions = {
     start: function(controller) {


### PR DESCRIPTION
This PR configures web-streams to use GitHub Actions. It also updates the installation instructions to refer to [Spago](https://github.com/purescript/spago) instead of Bower and adds a Pursuit link.